### PR TITLE
Don't explicitly set the step size, derive it from the number of steps instead

### DIFF
--- a/voicebox_pytorch/voicebox_pytorch.py
+++ b/voicebox_pytorch/voicebox_pytorch.py
@@ -1123,7 +1123,6 @@ class ConditionalFlowMatcherWrapper(Module):
         sigma = 0.,
         ode_atol = 1e-5,
         ode_rtol = 1e-5,
-        ode_step_size = 0.0625,
         use_torchode = False,
         torchdiffeq_ode_method = 'midpoint',   # use midpoint for torchdiffeq, as in paper
         torchode_method_klass = to.Tsit5,      # use tsit5 for torchode, as torchode does not have midpoint (recommended by Bryan @b-chiang)
@@ -1152,8 +1151,7 @@ class ConditionalFlowMatcherWrapper(Module):
         self.odeint_kwargs = dict(
             atol = ode_atol,
             rtol = ode_rtol,
-            method = torchdiffeq_ode_method,
-            options = dict(step_size = ode_step_size)
+            method = torchdiffeq_ode_method
         )
 
     @property


### PR DESCRIPTION
I noticed inference time was static even when changing the number of ODE steps, and it looks like the step size is being provided explicitly at init instead of deriving it from the steps -> sample times array during sampling. Not setting this parameter allows sampling to use the correct number of steps, and acts as a time/quality tradeoff.

Here are some examples using power-of-2 step increments as described in the paper — there's a noticeable quality improvement when evaluating the flow at more timesteps:

[4 Steps](https://s3.amazonaws.com/lucasnewman.datasets/voicebox/samples/4-steps.wav)
[8 Steps](https://s3.amazonaws.com/lucasnewman.datasets/voicebox/samples/8-steps.wav)
[16 Steps](https://s3.amazonaws.com/lucasnewman.datasets/voicebox/samples/16-steps.wav)
[32 Steps](https://s3.amazonaws.com/lucasnewman.datasets/voicebox/samples/32-steps.wav)
[64 Steps](https://s3.amazonaws.com/lucasnewman.datasets/voicebox/samples/64-steps.wav)
[128 Steps](https://s3.amazonaws.com/lucasnewman.datasets/voicebox/samples/128-steps.wav)