### PR TITLE
Fix conditioning to allow speech in-filling

### DIFF
--- a/voicebox_pytorch/voicebox_pytorch.py
+++ b/voicebox_pytorch/voicebox_pytorch.py
@@ -990,10 +990,10 @@ class VoiceBox(Module):
 
         x = self.proj_in(x)
 
+        cond = default(cond, target)
+
         if exists(cond):
             cond = self.proj_in(cond)
-
-        cond = default(cond, x)
 
         # shapes
 
@@ -1012,11 +1012,8 @@ class VoiceBox(Module):
 
         if self.training:
             if not exists(cond_mask):
-                if coin_flip():
-                    frac_lengths = torch.zeros((batch,), device = self.device).float().uniform_(*self.frac_lengths_mask)
-                    cond_mask = mask_from_frac_lengths(seq_len, frac_lengths)
-                else:
-                    cond_mask = prob_mask_like((batch, seq_len), self.p_drop_prob, self.device)
+                frac_lengths = torch.zeros((batch,), device = self.device).float().uniform_(*self.frac_lengths_mask)
+                cond_mask = mask_from_frac_lengths(seq_len, frac_lengths)
         else:
             if not exists(cond_mask):
                 cond_mask = torch.ones((batch, seq_len), device = cond.device, dtype = torch.bool)
@@ -1025,7 +1022,6 @@ class VoiceBox(Module):
 
         # as described in section 3.2
 
-        x = x * cond_mask_with_pad_dim
         cond = cond * ~cond_mask_with_pad_dim
 
         # classifier free guidance


### PR DESCRIPTION
There are a few tweaks to conditioning needed to allow speech in-filling as described in the paper to work correctly. This is a small code change but a relatively large functional change, so I'm open to discussion!

1) During training, use the un-noised target as the conditioning (aka X_ctx in the paper) instead of the X_t value for the previous timestep in the flow. Without this, the conditioning is noisy and the network can't correctly use the full context to predict the flow for the in-filling portion.

2) Remove the MLM-style training objective and only use fractional masking for training efficiency, since the target is the final step of the flow based on the X_t intermediate step and not an unmasked version of the input.

3) Don't mask the input X_t of the flow, since that's basically throwing away information sampled at previous timesteps of the ODE. The network will learn to sample X_ctx and generate in-filled speech where appropriate based on the conditioning mask.

With these changes, I was able to train a model that supports speech in-filling with style transfer at inference time! 🚀