### PR TITLE
Fix CFG calculation

### DIFF
--- a/voicebox_pytorch/voicebox_pytorch.py
+++ b/voicebox_pytorch/voicebox_pytorch.py
@@ -982,7 +982,7 @@ class VoiceBox(Module):
             return logits
 
         null_logits = self.forward(*args, cond_drop_prob = 1., **kwargs)
-        return null_logits + (logits - null_logits) * cond_scale
+        return logits + (logits - null_logits) * cond_scale
 
     def forward(
         self,


### PR DESCRIPTION
Voicebox paper suggest to use this formula:
![image](https://github.com/lucidrains/voicebox-pytorch/assets/46067553/164caede-5c23-41ee-8c44-be646115ffcb)

But currently there is used such formula:
![telegram-cloud-photo-size-2-5368554922540392086-y](https://github.com/lucidrains/voicebox-pytorch/assets/46067553/3824bfbb-e8dd-4543-afb3-ea41b8aea0b5)


